### PR TITLE
geom_alt props

### DIFF
--- a/data/421/174/919/421174919.geojson
+++ b/data/421/174/919/421174919.geojson
@@ -282,6 +282,9 @@
     },
     "wof:country":"KP",
     "wof:created":1459009048,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"184bbf6981a86269d5a4cb5abbd0caa1",
     "wof:hierarchy":[
         {
@@ -293,7 +296,7 @@
         }
     ],
     "wof:id":421174919,
-    "wof:lastmodified":1566584575,
+    "wof:lastmodified":1582315790,
     "wof:name":"Manp'o",
     "wof:parent_id":1108747007,
     "wof:placetype":"locality",

--- a/data/421/188/981/421188981.geojson
+++ b/data/421/188/981/421188981.geojson
@@ -521,6 +521,9 @@
     },
     "wof:country":"KP",
     "wof:created":1459009595,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"87bf6ab4ae9ef52b8887aa5c945963f5",
     "wof:hierarchy":[
         {
@@ -532,7 +535,7 @@
         }
     ],
     "wof:id":421188981,
-    "wof:lastmodified":1566584576,
+    "wof:lastmodified":1582315790,
     "wof:name":"Pyongyang",
     "wof:parent_id":1108747951,
     "wof:placetype":"locality",

--- a/data/421/199/693/421199693.geojson
+++ b/data/421/199/693/421199693.geojson
@@ -58,6 +58,9 @@
     },
     "wof:country":"KP",
     "wof:created":1459009998,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e9e80e51354566342f88ec00ec1fbc1",
     "wof:hierarchy":[
         {
@@ -73,7 +76,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566584577,
+    "wof:lastmodified":1582315790,
     "wof:name":"Namp\u00b4o-si",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/326/39/85632639.geojson
+++ b/data/856/326/39/85632639.geojson
@@ -1130,8 +1130,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1204,7 +1203,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1582315763,
+    "wof:lastmodified":1583202699,
     "wof:name":"North Korea",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/326/39/85632639.geojson
+++ b/data/856/326/39/85632639.geojson
@@ -1130,7 +1130,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso"
+        "meso",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1184,6 +1185,11 @@
     },
     "wof:country":"KP",
     "wof:country_alpha3":"PRK",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"3bee8d9516271cf0c3f0a0f03dfcbddf",
     "wof:hierarchy":[
         {
@@ -1198,7 +1204,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566582524,
+    "wof:lastmodified":1582315763,
     "wof:name":"North Korea",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/766/03/85676603.geojson
+++ b/data/856/766/03/85676603.geojson
@@ -293,6 +293,9 @@
         "wk:page":"North Hwanghae Province"
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"edf34186aa6f4167957e4c2c0237f860",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566582512,
+    "wof:lastmodified":1582315759,
     "wof:name":"Hwanghae-bukto",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/05/85676605.geojson
+++ b/data/856/766/05/85676605.geojson
@@ -293,6 +293,9 @@
         "wk:page":"South Hwanghae Province"
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f716efe9854c252c6527bb369a01576c",
     "wof:hierarchy":[
         {
@@ -308,7 +311,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566582514,
+    "wof:lastmodified":1582315760,
     "wof:name":"Hwanghae-namdo",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/11/85676611.geojson
+++ b/data/856/766/11/85676611.geojson
@@ -655,6 +655,9 @@
         "wd:id":"Q18808"
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f316fdfbc22c767e9f31071430e0bf4",
     "wof:hierarchy":[
         {
@@ -670,7 +673,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566582515,
+    "wof:lastmodified":1582315760,
     "wof:name":"P'y\u014fngyang",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/15/85676615.geojson
+++ b/data/856/766/15/85676615.geojson
@@ -211,6 +211,9 @@
         "wk:page":"North Hamgyong Province"
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"428d374850305aa80bcf61edb34d0dfd",
     "wof:hierarchy":[
         {
@@ -226,7 +229,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566582522,
+    "wof:lastmodified":1582315762,
     "wof:name":"Hamgy\u014fng-bukto",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/19/85676619.geojson
+++ b/data/856/766/19/85676619.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Kangwon Province (North Korea)"
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"59735012c997c4729e64a807280966ad",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566582516,
+    "wof:lastmodified":1582315761,
     "wof:name":"Kangw\u014fn-do",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/23/85676623.geojson
+++ b/data/856/766/23/85676623.geojson
@@ -305,6 +305,9 @@
         "wk:page":"Chagang Province"
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ebec4a723ccb6020956dd1bb684115a0",
     "wof:hierarchy":[
         {
@@ -320,7 +323,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566582520,
+    "wof:lastmodified":1582315762,
     "wof:name":"Chagang-do",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/29/85676629.geojson
+++ b/data/856/766/29/85676629.geojson
@@ -309,6 +309,9 @@
         "wk:page":"South Hamgyong Province"
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"351336470830f66d4d5e9f7da2db951e",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566582515,
+    "wof:lastmodified":1582315760,
     "wof:name":"Hamgy\u014fng-namdo",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/33/85676633.geojson
+++ b/data/856/766/33/85676633.geojson
@@ -306,6 +306,9 @@
         "wk:page":"North Pyongan Province"
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8732eec1039bcf9b96a61e50c112b832",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566582513,
+    "wof:lastmodified":1582315760,
     "wof:name":"P'y\u014fngan-bukto",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/37/85676637.geojson
+++ b/data/856/766/37/85676637.geojson
@@ -303,6 +303,9 @@
         "wk:page":"South Pyongan Province"
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"35ba1b7b809cdbfa631c9dff665ffe87",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566582517,
+    "wof:lastmodified":1582315761,
     "wof:name":"P'y\u014fngan-namdo",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/41/85676641.geojson
+++ b/data/856/766/41/85676641.geojson
@@ -304,6 +304,9 @@
         "wk:page":"Ryanggang Province"
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c0f2909a2f0802376a25819a8eec43ae",
     "wof:hierarchy":[
         {
@@ -319,7 +322,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566582519,
+    "wof:lastmodified":1582315761,
     "wof:name":"Ryanggang",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/47/85676647.geojson
+++ b/data/856/766/47/85676647.geojson
@@ -193,6 +193,9 @@
         "wk:page":"North Hamgyong Province"
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ab470add4339f5bbd939e1396a313118",
     "wof:hierarchy":[
         {
@@ -208,7 +211,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1566582523,
+    "wof:lastmodified":1582315762,
     "wof:name":"Ras\u014fn",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/859/027/39/85902739.geojson
+++ b/data/859/027/39/85902739.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":898568
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0f5806d0afd7948f7dff769f5f56255a",
     "wof:hierarchy":[
         {
@@ -96,7 +100,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566582511,
+    "wof:lastmodified":1582315759,
     "wof:name":"Ch'\u014fngam-ni",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/43/85902743.geojson
+++ b/data/859/027/43/85902743.geojson
@@ -72,6 +72,9 @@
         "gp:id":1071366
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e569af369cb8b6b658af0fb2f37b3918",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566582511,
+    "wof:lastmodified":1582315759,
     "wof:name":"Inh\u00feng-ni",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/45/85902745.geojson
+++ b/data/859/027/45/85902745.geojson
@@ -70,6 +70,9 @@
         "gp:id":1074428
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d34516f91e4a70d3650605a50f871957",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566582511,
+    "wof:lastmodified":1582315759,
     "wof:name":"Kurw\u014fn-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/47/85902747.geojson
+++ b/data/859/027/47/85902747.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":898569
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9ac3f18c74b99b1651973bd63fc076a6",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566582512,
+    "wof:lastmodified":1582315759,
     "wof:name":"Kyogu-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/49/85902749.geojson
+++ b/data/859/027/49/85902749.geojson
@@ -72,6 +72,9 @@
         "gp:id":1075759
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bea26642ccfde20014ecb8dd276cbf0f",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566582512,
+    "wof:lastmodified":1582315759,
     "wof:name":"Mir\u00fek-tong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/51/85902751.geojson
+++ b/data/859/027/51/85902751.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":229223
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7e435e303876c4b648cd32f7db541574",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566582511,
+    "wof:lastmodified":1582315759,
     "wof:name":"Munsu-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/53/85902753.geojson
+++ b/data/859/027/53/85902753.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1002386
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"627f6f013cd1b2a581015631bb8786ce",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566582511,
+    "wof:lastmodified":1582315759,
     "wof:name":"P'y\u014fngch'\u014fn-ni",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/55/85902755.geojson
+++ b/data/859/027/55/85902755.geojson
@@ -72,6 +72,9 @@
         "gp:id":1083077
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cefc51da6c4734003a65a1543853b791",
     "wof:hierarchy":[
         {
@@ -87,7 +90,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566582511,
+    "wof:lastmodified":1582315759,
     "wof:name":"Sanh\u00feng-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/57/85902757.geojson
+++ b/data/859/027/57/85902757.geojson
@@ -67,6 +67,9 @@
         "gp:id":1084504
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"233fced26889c9f78f2ee975ae1bfe4d",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566582511,
+    "wof:lastmodified":1582315759,
     "wof:name":"Sinni-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/61/85902761.geojson
+++ b/data/859/027/61/85902761.geojson
@@ -72,6 +72,10 @@
         "qs_pg:id":1107406
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"d27dd671549879d2046f6a1413c55aba",
     "wof:hierarchy":[
         {
@@ -87,7 +91,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566582511,
+    "wof:lastmodified":1582315759,
     "wof:name":"Tongdaew\u014fn-ni",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/027/63/85902763.geojson
+++ b/data/859/027/63/85902763.geojson
@@ -75,6 +75,10 @@
         "qs_pg:id":1167865
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"9146fcda74dc544bb69dce77f7b8d2da",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566582512,
+    "wof:lastmodified":1582315759,
     "wof:name":"Yongbuk-tong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/256/89/85925689.geojson
+++ b/data/859/256/89/85925689.geojson
@@ -85,6 +85,9 @@
         "qs_pg:id":11408
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bc6a418853e81e8170f5d58364201718",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566582510,
+    "wof:lastmodified":1582315758,
     "wof:name":"\uc6d0\uc2e0\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/273/51/85927351.geojson
+++ b/data/859/273/51/85927351.geojson
@@ -67,6 +67,9 @@
         "qs_pg:id":241689
     },
     "wof:country":"KP",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"0ef027a06e69e62d4f9da797be76536c",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1566582510,
+    "wof:lastmodified":1582315758,
     "wof:name":"\uc6a9\uc720\ub3d9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/416/365/890416365.geojson
+++ b/data/890/416/365/890416365.geojson
@@ -67,6 +67,9 @@
     },
     "wof:country":"KP",
     "wof:created":1469051130,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"0bbf1024d6a67585cb207d2d218f0109",
     "wof:hierarchy":[
         {
@@ -78,7 +81,7 @@
         }
     ],
     "wof:id":890416365,
-    "wof:lastmodified":1566584582,
+    "wof:lastmodified":1582315790,
     "wof:name":"Sunan",
     "wof:parent_id":1108747951,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.