### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/112/606/084/7/1126060847.geojson
+++ b/data/112/606/084/7/1126060847.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Hwanghak-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\ud669\ud559\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126060847,
-    "wof:lastmodified":1566584587,
-    "wof:name":"\ud669\ud559\ub3d9",
+    "wof:lastmodified":1601068496,
+    "wof:name":"Hwanghak-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/606/084/7/1126060847.geojson
+++ b/data/112/606/084/7/1126060847.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uc11c\uc6b8",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676619,
         102191569,
         85632639,
-        1108747727
+        1108747727,
+        85676619
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126060847,
-    "wof:lastmodified":1601068496,
+    "wof:lastmodified":1601423111,
     "wof:name":"Hwanghak-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/606/339/9/1126063399.geojson
+++ b/data/112/606/339/9/1126063399.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uacbd\uae30\ub3c4",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676603,
         102191569,
         85632639,
-        1108746915
+        1108746915,
+        85676603
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126063399,
-    "wof:lastmodified":1601068479,
+    "wof:lastmodified":1601423133,
     "wof:name":"Wonsin-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/606/339/9/1126063399.geojson
+++ b/data/112/606/339/9/1126063399.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Wonsin-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\uc6d0\uc2e0\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126063399,
-    "wof:lastmodified":1566584587,
-    "wof:name":"\uc6d0\uc2e0\ub3d9",
+    "wof:lastmodified":1601068479,
+    "wof:name":"Wonsin-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/606/438/1/1126064381.geojson
+++ b/data/112/606/438/1/1126064381.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uc11c\uc6b8",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676603,
         102191569,
         85632639,
-        1108747043
+        1108747043,
+        85676603
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126064381,
-    "wof:lastmodified":1601068448,
+    "wof:lastmodified":1601423108,
     "wof:name":"Gusan-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/606/438/1/1126064381.geojson
+++ b/data/112/606/438/1/1126064381.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Gusan-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\uad6c\uc0b0\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126064381,
-    "wof:lastmodified":1566584587,
-    "wof:name":"\uad6c\uc0b0\ub3d9",
+    "wof:lastmodified":1601068448,
+    "wof:name":"Gusan-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/606/808/1/1126068081.geojson
+++ b/data/112/606/808/1/1126068081.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Yongyu-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\uc6a9\uc720\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126068081,
-    "wof:lastmodified":1566584588,
-    "wof:name":"\uc6a9\uc720\ub3d9",
+    "wof:lastmodified":1601068478,
+    "wof:name":"Yongyu-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/606/808/1/1126068081.geojson
+++ b/data/112/606/808/1/1126068081.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uc778\ucc9c",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676605,
         102191569,
         85632639,
-        1108747729
+        1108747729,
+        85676605
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126068081,
-    "wof:lastmodified":1601068478,
+    "wof:lastmodified":1601423135,
     "wof:name":"Yongyu-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/607/704/3/1126077043.geojson
+++ b/data/112/607/704/3/1126077043.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Mabuk-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\ub9c8\ubd81\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126077043,
-    "wof:lastmodified":1566584588,
-    "wof:name":"\ub9c8\ubd81\ub3d9",
+    "wof:lastmodified":1601068457,
+    "wof:name":"Mabuk-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/607/704/3/1126077043.geojson
+++ b/data/112/607/704/3/1126077043.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uacbd\uae30\ub3c4",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676603,
         102191569,
         85632639,
-        1108747805
+        1108747805,
+        85676603
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126077043,
-    "wof:lastmodified":1601068457,
+    "wof:lastmodified":1601423118,
     "wof:name":"Mabuk-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/608/135/5/1126081355.geojson
+++ b/data/112/608/135/5/1126081355.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uacbd\uae30\ub3c4",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676619,
         102191569,
         85632639,
-        1108747727
+        1108747727,
+        85676619
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126081355,
-    "wof:lastmodified":1601068494,
+    "wof:lastmodified":1601423111,
     "wof:name":"Hosu-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/608/135/5/1126081355.geojson
+++ b/data/112/608/135/5/1126081355.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Hosu-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\ud638\uc218\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126081355,
-    "wof:lastmodified":1566584587,
-    "wof:name":"\ud638\uc218\ub3d9",
+    "wof:lastmodified":1601068494,
+    "wof:name":"Hosu-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/608/212/3/1126082123.geojson
+++ b/data/112/608/212/3/1126082123.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uc11c\uc6b8",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676603,
         102191569,
         85632639,
-        1108746915
+        1108746915,
+        85676603
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126082123,
-    "wof:lastmodified":1601068470,
+    "wof:lastmodified":1601423130,
     "wof:name":"Sugung-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/608/212/3/1126082123.geojson
+++ b/data/112/608/212/3/1126082123.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Sugung-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\uc218\uad81\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126082123,
-    "wof:lastmodified":1566584587,
-    "wof:name":"\uc218\uad81\ub3d9",
+    "wof:lastmodified":1601068470,
+    "wof:name":"Sugung-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/608/276/9/1126082769.geojson
+++ b/data/112/608/276/9/1126082769.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uacbd\uae30\ub3c4",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676605,
         102191569,
         85632639,
-        1108747905
+        1108747905,
+        85676605
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126082769,
-    "wof:lastmodified":1601068453,
+    "wof:lastmodified":1601423101,
     "wof:name":"Dalan-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/608/276/9/1126082769.geojson
+++ b/data/112/608/276/9/1126082769.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Dalan-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\ub2ec\uc548\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126082769,
-    "wof:lastmodified":1566584587,
-    "wof:name":"\ub2ec\uc548\ub3d9",
+    "wof:lastmodified":1601068453,
+    "wof:name":"Dalan-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/609/041/1/1126090411.geojson
+++ b/data/112/609/041/1/1126090411.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uacbd\uae30\ub3c4",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676605,
         102191569,
         85632639,
-        1108748107
+        1108748107,
+        85676605
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126090411,
-    "wof:lastmodified":1601068448,
+    "wof:lastmodified":1601423107,
     "wof:name":"Goean-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/609/041/1/1126090411.geojson
+++ b/data/112/609/041/1/1126090411.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Goean-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\uad34\uc548\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126090411,
-    "wof:lastmodified":1566584588,
-    "wof:name":"\uad34\uc548\ub3d9",
+    "wof:lastmodified":1601068448,
+    "wof:name":"Goean-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/609/175/1/1126091751.geojson
+++ b/data/112/609/175/1/1126091751.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Muak-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\ubb34\uc545\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126091751,
-    "wof:lastmodified":1566584588,
-    "wof:name":"\ubb34\uc545\ub3d9",
+    "wof:lastmodified":1601068458,
+    "wof:name":"Muak-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/609/175/1/1126091751.geojson
+++ b/data/112/609/175/1/1126091751.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uc11c\uc6b8",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676603,
         102191569,
         85632639,
-        1108747851
+        1108747851,
+        85676603
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126091751,
-    "wof:lastmodified":1601068458,
+    "wof:lastmodified":1601423119,
     "wof:name":"Muak-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/609/175/3/1126091753.geojson
+++ b/data/112/609/175/3/1126091753.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Gyonam-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\uad50\ub0a8\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126091753,
-    "wof:lastmodified":1566584588,
-    "wof:name":"\uad50\ub0a8\ub3d9",
+    "wof:lastmodified":1601068448,
+    "wof:name":"Gyonam-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/609/175/3/1126091753.geojson
+++ b/data/112/609/175/3/1126091753.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uc11c\uc6b8",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676603,
         102191569,
         85632639,
-        1108746915
+        1108746915,
+        85676603
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126091753,
-    "wof:lastmodified":1601068448,
+    "wof:lastmodified":1601423109,
     "wof:name":"Gyonam-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/609/175/7/1126091757.geojson
+++ b/data/112/609/175/7/1126091757.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Pil-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\ud544\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126091757,
-    "wof:lastmodified":1566584588,
-    "wof:name":"\ud544\ub3d9",
+    "wof:lastmodified":1601068492,
+    "wof:name":"Pil-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/609/175/7/1126091757.geojson
+++ b/data/112/609/175/7/1126091757.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uc11c\uc6b8",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676603,
         102191569,
         85632639,
-        1108747851
+        1108747851,
+        85676603
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126091757,
-    "wof:lastmodified":1601068492,
+    "wof:lastmodified":1601423123,
     "wof:name":"Pil-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/609/582/3/1126095823.geojson
+++ b/data/112/609/582/3/1126095823.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uc11c\uc6b8",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676603,
         102191569,
         85632639,
-        1108747189
+        1108747189,
+        85676603
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126095823,
-    "wof:lastmodified":1601068463,
+    "wof:lastmodified":1601423124,
     "wof:name":"Sageun-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/609/582/3/1126095823.geojson
+++ b/data/112/609/582/3/1126095823.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Sageun-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\uc0ac\uadfc\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126095823,
-    "wof:lastmodified":1566584588,
-    "wof:name":"\uc0ac\uadfc\ub3d9",
+    "wof:lastmodified":1601068463,
+    "wof:name":"Sageun-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/609/653/5/1126096535.geojson
+++ b/data/112/609/653/5/1126096535.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Hwajeong 1(il)-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\ud654\uc8151\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126096535,
-    "wof:lastmodified":1566584588,
-    "wof:name":"\ud654\uc8151\ub3d9",
+    "wof:lastmodified":1601068495,
+    "wof:name":"Hwajeong 1(il)-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/609/653/5/1126096535.geojson
+++ b/data/112/609/653/5/1126096535.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uacbd\uae30\ub3c4",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676603,
         102191569,
         85632639,
-        1108746915
+        1108746915,
+        85676603
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126096535,
-    "wof:lastmodified":1601068495,
+    "wof:lastmodified":1601423111,
     "wof:name":"Hwajeong 1(il)-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/112/610/059/1/1126100591.geojson
+++ b/data/112/610/059/1/1126100591.geojson
@@ -21,6 +21,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:eng_x_preferred":[
+        "Munhak-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\ubb38\ud559\ub3d9"
+    ],
     "qs_pg:aaroncc":"KP",
     "qs_pg:gn_country":"KP",
     "qs_pg:gn_fcode":"PPL",
@@ -73,8 +79,8 @@
         }
     ],
     "wof:id":1126100591,
-    "wof:lastmodified":1566584585,
-    "wof:name":"\ubb38\ud559\ub3d9",
+    "wof:lastmodified":1601068459,
+    "wof:name":"Munhak-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/112/610/059/1/1126100591.geojson
+++ b/data/112/610/059/1/1126100591.geojson
@@ -54,10 +54,10 @@
     "woe:name_adm1":"\uc778\ucc9c",
     "woe:placetype":"Suburb",
     "wof:belongsto":[
-        85676605,
         102191569,
         85632639,
-        1108747729
+        1108747729,
+        85676605
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1126100591,
-    "wof:lastmodified":1601068459,
+    "wof:lastmodified":1601423119,
     "wof:name":"Munhak-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/172/039/421172039.geojson
+++ b/data/421/172/039/421172039.geojson
@@ -42,10 +42,10 @@
     "qs:woe_id":28806785,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676605,
         102191569,
         85632639,
-        1108747905
+        1108747905,
+        85676605
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421172039,
-    "wof:lastmodified":1601068444,
+    "wof:lastmodified":1601423104,
     "wof:name":"Galsan-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/172/039/421172039.geojson
+++ b/data/421/172/039/421172039.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Galsan-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\uac08\uc0b0\ub3d9"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421172039,
-    "wof:lastmodified":1566584576,
-    "wof:name":"\uac08\uc0b0\ub3d9",
+    "wof:lastmodified":1601068444,
+    "wof:name":"Galsan-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/421/185/697/421185697.geojson
+++ b/data/421/185/697/421185697.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Hwajeong 2(i)-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\ud654\uc8152\ub3d9"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -60,8 +66,8 @@
         }
     ],
     "wof:id":421185697,
-    "wof:lastmodified":1566584579,
-    "wof:name":"\ud654\uc8152\ub3d9",
+    "wof:lastmodified":1601068495,
+    "wof:name":"Hwajeong 2(i)-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/421/185/697/421185697.geojson
+++ b/data/421/185/697/421185697.geojson
@@ -42,10 +42,10 @@
     "qs:woe_id":28806906,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676603,
         102191569,
         85632639,
-        1108746915
+        1108746915,
+        85676603
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":421185697,
-    "wof:lastmodified":1601068495,
+    "wof:lastmodified":1601423111,
     "wof:name":"Hwajeong 2(i)-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/188/537/421188537.geojson
+++ b/data/421/188/537/421188537.geojson
@@ -45,10 +45,10 @@
     "qs:woe_id":28806889,
     "src:geom":"quattroshapes",
     "wof:belongsto":[
-        85676605,
         102191569,
         85632639,
-        1108747061
+        1108747061,
+        85676605
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -70,7 +70,7 @@
         }
     ],
     "wof:id":421188537,
-    "wof:lastmodified":1601068490,
+    "wof:lastmodified":1601423099,
     "wof:name":"Choji-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/188/537/421188537.geojson
+++ b/data/421/188/537/421188537.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:eng_x_preferred":[
+        "Choji-dong"
+    ],
+    "name:kor_x_preferred":[
+        "\ucd08\uc9c0\ub3d9"
+    ],
     "name:und_x_variant":[
         "\uc624\uc9c0\ub3d9"
     ],
@@ -64,8 +70,8 @@
         }
     ],
     "wof:id":421188537,
-    "wof:lastmodified":1566584576,
-    "wof:name":"\ucd08\uc9c0\ub3d9",
+    "wof:lastmodified":1601068490,
+    "wof:name":"Choji-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/859/273/51/85927351.geojson
+++ b/data/859/273/51/85927351.geojson
@@ -27,7 +27,13 @@
     "mz:max_zoom":18.0,
     "mz:min_zoom":13.0,
     "mz:tier_locality":2,
+    "name:eng_x_preferred":[
+        "Yongyu-dong"
+    ],
     "name:kor_x_preferred":[
+        "\uc6a9\uc720\ub3d9"
+    ],
+    "name:kor_x_variant":[
         "\uc6a9\uc720\ub3d9"
     ],
     "qs:gn_adm0_cc":"KR",
@@ -84,8 +90,8 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1582315758,
-    "wof:name":"\uc6a9\uc720\ub3d9",
+    "wof:lastmodified":1601068478,
+    "wof:name":"Yongyu-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-kp",

--- a/data/859/273/51/85927351.geojson
+++ b/data/859/273/51/85927351.geojson
@@ -33,9 +33,6 @@
     "name:kor_x_preferred":[
         "\uc6a9\uc720\ub3d9"
     ],
-    "name:kor_x_variant":[
-        "\uc6a9\uc720\ub3d9"
-    ],
     "qs:gn_adm0_cc":"KR",
     "qs:gn_fcode":"PPL",
     "qs:gn_local":1843564,
@@ -90,7 +87,7 @@
     "wof:lang":[
         "kor"
     ],
-    "wof:lastmodified":1601068478,
+    "wof:lastmodified":1601423135,
     "wof:name":"Yongyu-dong",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.