### PR TITLE
kp concordances, placetype local, and more

### DIFF
--- a/data/110/874/684/3/1108746843.geojson
+++ b/data/110/874/684/3/1108746843.geojson
@@ -77,7 +77,7 @@
         }
     ],
     "wof:id":1108746843,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886620,
     "wof:name":"Anak",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/684/5/1108746845.geojson
+++ b/data/110/874/684/5/1108746845.geojson
@@ -134,7 +134,7 @@
         }
     ],
     "wof:id":1108746845,
-    "wof:lastmodified":1694498096,
+    "wof:lastmodified":1695886623,
     "wof:name":"Anbyon",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/684/7/1108746847.geojson
+++ b/data/110/874/684/7/1108746847.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746847,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886753,
     "wof:name":"Anju City",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/684/9/1108746849.geojson
+++ b/data/110/874/684/9/1108746849.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746849,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886753,
     "wof:name":"Changdo",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/686/3/1108746863.geojson
+++ b/data/110/874/686/3/1108746863.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746863,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886753,
     "wof:name":"Chongjin City",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/686/5/1108746865.geojson
+++ b/data/110/874/686/5/1108746865.geojson
@@ -86,7 +86,7 @@
         }
     ],
     "wof:id":1108746865,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886754,
     "wof:name":"Chongnam",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/686/7/1108746867.geojson
+++ b/data/110/874/686/7/1108746867.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746867,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886754,
     "wof:name":"Chonma",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/686/9/1108746869.geojson
+++ b/data/110/874/686/9/1108746869.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746869,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886754,
     "wof:name":"Chonnae",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/688/1/1108746881.geojson
+++ b/data/110/874/688/1/1108746881.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746881,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886754,
     "wof:name":"Hochon",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/688/3/1108746883.geojson
+++ b/data/110/874/688/3/1108746883.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746883,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886754,
     "wof:name":"Hoechang",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/688/5/1108746885.geojson
+++ b/data/110/874/688/5/1108746885.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746885,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886754,
     "wof:name":"Hoeryong City",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/688/7/1108746887.geojson
+++ b/data/110/874/688/7/1108746887.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746887,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886754,
     "wof:name":"Hoeyang",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/688/9/1108746889.geojson
+++ b/data/110/874/688/9/1108746889.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746889,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886754,
     "wof:name":"Hongwon",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/690/1/1108746901.geojson
+++ b/data/110/874/690/1/1108746901.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746901,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886754,
     "wof:name":"Hyangsan",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/690/3/1108746903.geojson
+++ b/data/110/874/690/3/1108746903.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746903,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886755,
     "wof:name":"Hyesan City",
     "wof:parent_id":85676641,
     "wof:placetype":"county",

--- a/data/110/874/690/5/1108746905.geojson
+++ b/data/110/874/690/5/1108746905.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1108746905,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886755,
     "wof:name":"Ichon",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/690/7/1108746907.geojson
+++ b/data/110/874/690/7/1108746907.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746907,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886755,
     "wof:name":"Jaeryong",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/691/1/1108746911.geojson
+++ b/data/110/874/691/1/1108746911.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746911,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886760,
     "wof:name":"Janggang",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/691/3/1108746913.geojson
+++ b/data/110/874/691/3/1108746913.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746913,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886755,
     "wof:name":"Jangjin",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/691/5/1108746915.geojson
+++ b/data/110/874/691/5/1108746915.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746915,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886755,
     "wof:name":"Jangphung",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/691/7/1108746917.geojson
+++ b/data/110/874/691/7/1108746917.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746917,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886755,
     "wof:name":"Jangyon",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/691/9/1108746919.geojson
+++ b/data/110/874/691/9/1108746919.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746919,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886755,
     "wof:name":"Jasong",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/695/1/1108746951.geojson
+++ b/data/110/874/695/1/1108746951.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746951,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kangso",
     "wof:parent_id":421199693,
     "wof:placetype":"county",

--- a/data/110/874/695/3/1108746953.geojson
+++ b/data/110/874/695/3/1108746953.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746953,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kapsan",
     "wof:parent_id":85676641,
     "wof:placetype":"county",

--- a/data/110/874/695/5/1108746955.geojson
+++ b/data/110/874/695/5/1108746955.geojson
@@ -77,7 +77,7 @@
         }
     ],
     "wof:id":1108746955,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kilju",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/695/7/1108746957.geojson
+++ b/data/110/874/695/7/1108746957.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746957,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kim Chaek City",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/695/9/1108746959.geojson
+++ b/data/110/874/695/9/1108746959.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746959,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kim Hyong Gwon",
     "wof:parent_id":85676641,
     "wof:placetype":"county",

--- a/data/110/874/696/1/1108746961.geojson
+++ b/data/110/874/696/1/1108746961.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746961,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kim Jong Suk",
     "wof:parent_id":85676641,
     "wof:placetype":"county",

--- a/data/110/874/696/5/1108746965.geojson
+++ b/data/110/874/696/5/1108746965.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746965,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kimh Yong Jik",
     "wof:parent_id":85676641,
     "wof:placetype":"county",

--- a/data/110/874/696/7/1108746967.geojson
+++ b/data/110/874/696/7/1108746967.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746967,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kimhwa",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/696/9/1108746969.geojson
+++ b/data/110/874/696/9/1108746969.geojson
@@ -71,7 +71,7 @@
         }
     ],
     "wof:id":1108746969,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886757,
     "wof:name":"Koksan",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/697/1/1108746971.geojson
+++ b/data/110/874/697/1/1108746971.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746971,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kophung",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/697/3/1108746973.geojson
+++ b/data/110/874/697/3/1108746973.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1108746973,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kosan",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/697/5/1108746975.geojson
+++ b/data/110/874/697/5/1108746975.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746975,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kosong",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/697/7/1108746977.geojson
+++ b/data/110/874/697/7/1108746977.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746977,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kowon",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/697/9/1108746979.geojson
+++ b/data/110/874/697/9/1108746979.geojson
@@ -74,7 +74,7 @@
         }
     ],
     "wof:id":1108746979,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kujang",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/699/3/1108746993.geojson
+++ b/data/110/874/699/3/1108746993.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746993,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kwail",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/699/5/1108746995.geojson
+++ b/data/110/874/699/5/1108746995.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746995,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kwaksan",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/699/7/1108746997.geojson
+++ b/data/110/874/699/7/1108746997.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108746997,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kyonghung",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/700/1/1108747001.geojson
+++ b/data/110/874/700/1/1108747001.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747001,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kyongsong",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/700/3/1108747003.geojson
+++ b/data/110/874/700/3/1108747003.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747003,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886764,
     "wof:name":"Kyongwon",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/700/5/1108747005.geojson
+++ b/data/110/874/700/5/1108747005.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747005,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886758,
     "wof:name":"Maengsan",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/700/7/1108747007.geojson
+++ b/data/110/874/700/7/1108747007.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747007,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886758,
     "wof:name":"Manpho City",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/700/9/1108747009.geojson
+++ b/data/110/874/700/9/1108747009.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747009,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886758,
     "wof:name":"Munchon City",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/701/1/1108747011.geojson
+++ b/data/110/874/701/1/1108747011.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747011,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886758,
     "wof:name":"Mundok",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/701/3/1108747013.geojson
+++ b/data/110/874/701/3/1108747013.geojson
@@ -131,7 +131,7 @@
         }
     ],
     "wof:id":1108747013,
-    "wof:lastmodified":1694498096,
+    "wof:lastmodified":1695886622,
     "wof:name":"Musan",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/701/5/1108747015.geojson
+++ b/data/110/874/701/5/1108747015.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747015,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886758,
     "wof:name":"Myongchon",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/701/9/1108747019.geojson
+++ b/data/110/874/701/9/1108747019.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747019,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886758,
     "wof:name":"Myonggan",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/702/1/1108747021.geojson
+++ b/data/110/874/702/1/1108747021.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108747021,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886758,
     "wof:name":"Nampho City",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/874/702/3/1108747023.geojson
+++ b/data/110/874/702/3/1108747023.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747023,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886758,
     "wof:name":"Nyongbyon",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/702/5/1108747025.geojson
+++ b/data/110/874/702/5/1108747025.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747025,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886758,
     "wof:name":"Nyongwon",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/702/7/1108747027.geojson
+++ b/data/110/874/702/7/1108747027.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747027,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886758,
     "wof:name":"Onchon",
     "wof:parent_id":421199693,
     "wof:placetype":"county",

--- a/data/110/874/702/9/1108747029.geojson
+++ b/data/110/874/702/9/1108747029.geojson
@@ -134,7 +134,7 @@
         }
     ],
     "wof:id":1108747029,
-    "wof:lastmodified":1694498096,
+    "wof:lastmodified":1695886623,
     "wof:name":"Ongjin",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/704/3/1108747043.geojson
+++ b/data/110/874/704/3/1108747043.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747043,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Panmun",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/704/5/1108747045.geojson
+++ b/data/110/874/704/5/1108747045.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747045,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Phangyo",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/704/7/1108747047.geojson
+++ b/data/110/874/704/7/1108747047.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747047,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Phihyon",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/704/9/1108747049.geojson
+++ b/data/110/874/704/9/1108747049.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747049,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Phungso",
     "wof:parent_id":85676641,
     "wof:placetype":"county",

--- a/data/110/874/706/1/1108747061.geojson
+++ b/data/110/874/706/1/1108747061.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747061,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Pongchon",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/706/3/1108747063.geojson
+++ b/data/110/874/706/3/1108747063.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747063,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Pongsan",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/706/5/1108747065.geojson
+++ b/data/110/874/706/5/1108747065.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747065,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Popdong",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/706/7/1108747067.geojson
+++ b/data/110/874/706/7/1108747067.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747067,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Pujon",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/706/9/1108747069.geojson
+++ b/data/110/874/706/9/1108747069.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747069,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886760,
     "wof:name":"Pukchang",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/709/1/1108747091.geojson
+++ b/data/110/874/709/1/1108747091.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747091,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886760,
     "wof:name":"Rason City",
     "wof:parent_id":85676647,
     "wof:placetype":"county",

--- a/data/110/874/709/3/1108747093.geojson
+++ b/data/110/874/709/3/1108747093.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747093,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886760,
     "wof:name":"Rinsan",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/709/5/1108747095.geojson
+++ b/data/110/874/709/5/1108747095.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747095,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886760,
     "wof:name":"Riwon",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/710/3/1108747103.geojson
+++ b/data/110/874/710/3/1108747103.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747103,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886761,
     "wof:name":"Ryongrim",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/710/5/1108747105.geojson
+++ b/data/110/874/710/5/1108747105.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747105,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886761,
     "wof:name":"Sakju",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/710/9/1108747109.geojson
+++ b/data/110/874/710/9/1108747109.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747109,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886761,
     "wof:name":"Samchon",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/711/1/1108747111.geojson
+++ b/data/110/874/711/1/1108747111.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747111,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886761,
     "wof:name":"Samjiyon",
     "wof:parent_id":85676641,
     "wof:placetype":"county",

--- a/data/110/874/711/3/1108747113.geojson
+++ b/data/110/874/711/3/1108747113.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747113,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886761,
     "wof:name":"Samsu",
     "wof:parent_id":85676641,
     "wof:placetype":"county",

--- a/data/110/874/711/5/1108747115.geojson
+++ b/data/110/874/711/5/1108747115.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747115,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886761,
     "wof:name":"Sangwon",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/711/7/1108747117.geojson
+++ b/data/110/874/711/7/1108747117.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747117,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886761,
     "wof:name":"Sariwon City",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/711/9/1108747119.geojson
+++ b/data/110/874/711/9/1108747119.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747119,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886762,
     "wof:name":"Sepho",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/712/1/1108747121.geojson
+++ b/data/110/874/712/1/1108747121.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747121,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886762,
     "wof:name":"Sijung",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/712/3/1108747123.geojson
+++ b/data/110/874/712/3/1108747123.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1108747123,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886762,
     "wof:name":"Sinchon",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/712/7/1108747127.geojson
+++ b/data/110/874/712/7/1108747127.geojson
@@ -71,7 +71,7 @@
         }
     ],
     "wof:id":1108747127,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886620,
     "wof:name":"Sindo",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/712/9/1108747129.geojson
+++ b/data/110/874/712/9/1108747129.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747129,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886762,
     "wof:name":"Sinhung",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/714/1/1108747141.geojson
+++ b/data/110/874/714/1/1108747141.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1108747141,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886762,
     "wof:name":"Sinyang",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/714/5/1108747145.geojson
+++ b/data/110/874/714/5/1108747145.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747145,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886762,
     "wof:name":"Sohung",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/714/7/1108747147.geojson
+++ b/data/110/874/714/7/1108747147.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747147,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886762,
     "wof:name":"Sonchon",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/714/9/1108747149.geojson
+++ b/data/110/874/714/9/1108747149.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747149,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886762,
     "wof:name":"Songchon",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/718/3/1108747183.geojson
+++ b/data/110/874/718/3/1108747183.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747183,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886764,
     "wof:name":"Thaechon",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/718/5/1108747185.geojson
+++ b/data/110/874/718/5/1108747185.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747185,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886764,
     "wof:name":"Thaethan",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/718/7/1108747187.geojson
+++ b/data/110/874/718/7/1108747187.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747187,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886764,
     "wof:name":"Thongchon",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/718/9/1108747189.geojson
+++ b/data/110/874/718/9/1108747189.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747189,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886764,
     "wof:name":"Thosan",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/719/1/1108747191.geojson
+++ b/data/110/874/719/1/1108747191.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747191,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886764,
     "wof:name":"Tokchon City",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/719/3/1108747193.geojson
+++ b/data/110/874/719/3/1108747193.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747193,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886764,
     "wof:name":"Toksong",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/719/5/1108747195.geojson
+++ b/data/110/874/719/5/1108747195.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747195,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886764,
     "wof:name":"Tongchang",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/719/9/1108747199.geojson
+++ b/data/110/874/719/9/1108747199.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747199,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886765,
     "wof:name":"Tongrim",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/720/1/1108747201.geojson
+++ b/data/110/874/720/1/1108747201.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747201,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886765,
     "wof:name":"Tongsin",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/720/3/1108747203.geojson
+++ b/data/110/874/720/3/1108747203.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747203,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886765,
     "wof:name":"Tukjang",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/720/5/1108747205.geojson
+++ b/data/110/874/720/5/1108747205.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747205,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886765,
     "wof:name":"Uiju",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/720/7/1108747207.geojson
+++ b/data/110/874/720/7/1108747207.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747207,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886765,
     "wof:name":"Unchon",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/720/9/1108747209.geojson
+++ b/data/110/874/720/9/1108747209.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747209,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886765,
     "wof:name":"Unhung",
     "wof:parent_id":85676641,
     "wof:placetype":"county",

--- a/data/110/874/721/1/1108747211.geojson
+++ b/data/110/874/721/1/1108747211.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747211,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886765,
     "wof:name":"Unjong",
     "wof:parent_id":85676611,
     "wof:placetype":"county",

--- a/data/110/874/721/3/1108747213.geojson
+++ b/data/110/874/721/3/1108747213.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747213,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886765,
     "wof:name":"Unjon",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/721/7/1108747217.geojson
+++ b/data/110/874/721/7/1108747217.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747217,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886765,
     "wof:name":"Unpha",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/721/9/1108747219.geojson
+++ b/data/110/874/721/9/1108747219.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747219,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886765,
     "wof:name":"Unryul",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/722/5/1108747225.geojson
+++ b/data/110/874/722/5/1108747225.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747225,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886765,
     "wof:name":"Usi",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/722/7/1108747227.geojson
+++ b/data/110/874/722/7/1108747227.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747227,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886765,
     "wof:name":"Wiwon",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/722/9/1108747229.geojson
+++ b/data/110/874/722/9/1108747229.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747229,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886766,
     "wof:name":"Wonsan City",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/772/1/1108747721.geojson
+++ b/data/110/874/772/1/1108747721.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747721,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886753,
     "wof:name":"Changsong",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/772/3/1108747723.geojson
+++ b/data/110/874/772/3/1108747723.geojson
@@ -104,7 +104,7 @@
         }
     ],
     "wof:id":1108747723,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886621,
     "wof:name":"Chollima",
     "wof:parent_id":421199693,
     "wof:placetype":"county",

--- a/data/110/874/772/5/1108747725.geojson
+++ b/data/110/874/772/5/1108747725.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747725,
-    "wof:lastmodified":1694498051,
+    "wof:lastmodified":1695886753,
     "wof:name":"Cholwan",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/772/7/1108747727.geojson
+++ b/data/110/874/772/7/1108747727.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747727,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886754,
     "wof:name":"Cholwon",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/772/9/1108747729.geojson
+++ b/data/110/874/772/9/1108747729.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747729,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886754,
     "wof:name":"Chongdan",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/774/1/1108747741.geojson
+++ b/data/110/874/774/1/1108747741.geojson
@@ -134,7 +134,7 @@
         }
     ],
     "wof:id":1108747741,
-    "wof:lastmodified":1694498096,
+    "wof:lastmodified":1695886623,
     "wof:name":"Chosan",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/774/3/1108747743.geojson
+++ b/data/110/874/774/3/1108747743.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747743,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886754,
     "wof:name":"Haeju City",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/774/5/1108747745.geojson
+++ b/data/110/874/774/5/1108747745.geojson
@@ -65,7 +65,7 @@
         }
     ],
     "wof:id":1108747745,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886754,
     "wof:name":"Hamhung City",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/774/7/1108747747.geojson
+++ b/data/110/874/774/7/1108747747.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747747,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886754,
     "wof:name":"Hamju",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/776/1/1108747761.geojson
+++ b/data/110/874/776/1/1108747761.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747761,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886755,
     "wof:name":"Huichon City",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/776/3/1108747763.geojson
+++ b/data/110/874/776/3/1108747763.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747763,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886755,
     "wof:name":"Hwadae",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/776/5/1108747765.geojson
+++ b/data/110/874/776/5/1108747765.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747765,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886755,
     "wof:name":"Hwangju",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/776/7/1108747767.geojson
+++ b/data/110/874/776/7/1108747767.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747767,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886755,
     "wof:name":"Hwaphyong",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/778/9/1108747789.geojson
+++ b/data/110/874/778/9/1108747789.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747789,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886755,
     "wof:name":"Jonchon",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/779/3/1108747793.geojson
+++ b/data/110/874/779/3/1108747793.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747793,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886755,
     "wof:name":"Jongju City",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/779/5/1108747795.geojson
+++ b/data/110/874/779/5/1108747795.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747795,
-    "wof:lastmodified":1694498052,
+    "wof:lastmodified":1695886754,
     "wof:name":"Jongphyong",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/779/7/1108747797.geojson
+++ b/data/110/874/779/7/1108747797.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747797,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886755,
     "wof:name":"Junggang",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/779/9/1108747799.geojson
+++ b/data/110/874/779/9/1108747799.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747799,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886755,
     "wof:name":"Junghwa",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/780/1/1108747801.geojson
+++ b/data/110/874/780/1/1108747801.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747801,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886756,
     "wof:name":"Jungsan",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/780/3/1108747803.geojson
+++ b/data/110/874/780/3/1108747803.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747803,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kaechon City",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/780/5/1108747805.geojson
+++ b/data/110/874/780/5/1108747805.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747805,
-    "wof:lastmodified":1694498053,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kaepung",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/780/7/1108747807.geojson
+++ b/data/110/874/780/7/1108747807.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747807,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kaesong City",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/781/1/1108747811.geojson
+++ b/data/110/874/781/1/1108747811.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747811,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kangdong",
     "wof:parent_id":85676611,
     "wof:placetype":"county",

--- a/data/110/874/781/3/1108747813.geojson
+++ b/data/110/874/781/3/1108747813.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747813,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kanggye City",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/781/5/1108747815.geojson
+++ b/data/110/874/781/5/1108747815.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747815,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886756,
     "wof:name":"Kangnam",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/781/7/1108747817.geojson
+++ b/data/110/874/781/7/1108747817.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747817,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kangryong",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/785/1/1108747851.geojson
+++ b/data/110/874/785/1/1108747851.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747851,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kumchon",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/785/3/1108747853.geojson
+++ b/data/110/874/785/3/1108747853.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1108747853,
-    "wof:lastmodified":1694497831,
+    "wof:lastmodified":1695886620,
     "wof:name":"Kumgang",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/785/5/1108747855.geojson
+++ b/data/110/874/785/5/1108747855.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747855,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kumho",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/785/7/1108747857.geojson
+++ b/data/110/874/785/7/1108747857.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747857,
-    "wof:lastmodified":1694498054,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kumya",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/785/9/1108747859.geojson
+++ b/data/110/874/785/9/1108747859.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747859,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886757,
     "wof:name":"Kusong City",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/790/1/1108747901.geojson
+++ b/data/110/874/790/1/1108747901.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747901,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886758,
     "wof:name":"Onsong",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/790/3/1108747903.geojson
+++ b/data/110/874/790/3/1108747903.geojson
@@ -68,7 +68,7 @@
         }
     ],
     "wof:id":1108747903,
-    "wof:lastmodified":1694498055,
+    "wof:lastmodified":1695886758,
     "wof:name":"Orang",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/790/5/1108747905.geojson
+++ b/data/110/874/790/5/1108747905.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747905,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Paechon",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/790/7/1108747907.geojson
+++ b/data/110/874/790/7/1108747907.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747907,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Paekam",
     "wof:parent_id":85676641,
     "wof:placetype":"county",

--- a/data/110/874/790/9/1108747909.geojson
+++ b/data/110/874/790/9/1108747909.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747909,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Pakchon",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/792/1/1108747921.geojson
+++ b/data/110/874/792/1/1108747921.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747921,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Phyoksong",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/792/3/1108747923.geojson
+++ b/data/110/874/792/3/1108747923.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747923,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Phyongsan",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/792/5/1108747925.geojson
+++ b/data/110/874/792/5/1108747925.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747925,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886759,
     "wof:name":"Phyongwon",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/792/7/1108747927.geojson
+++ b/data/110/874/792/7/1108747927.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747927,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886760,
     "wof:name":"Pochon",
     "wof:parent_id":85676641,
     "wof:placetype":"county",

--- a/data/110/874/794/1/1108747941.geojson
+++ b/data/110/874/794/1/1108747941.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747941,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886760,
     "wof:name":"Pukchong",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/794/3/1108747943.geojson
+++ b/data/110/874/794/3/1108747943.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747943,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886760,
     "wof:name":"Puryong",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/794/5/1108747945.geojson
+++ b/data/110/874/794/5/1108747945.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747945,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886760,
     "wof:name":"Pyokdong",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/794/7/1108747947.geojson
+++ b/data/110/874/794/7/1108747947.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747947,
-    "wof:lastmodified":1694498056,
+    "wof:lastmodified":1695886760,
     "wof:name":"Pyonggang",
     "wof:parent_id":85676619,
     "wof:placetype":"county",

--- a/data/110/874/794/9/1108747949.geojson
+++ b/data/110/874/794/9/1108747949.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747949,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886760,
     "wof:name":"Pyongsong City",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/795/1/1108747951.geojson
+++ b/data/110/874/795/1/1108747951.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747951,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886766,
     "wof:name":"Pyongyang City",
     "wof:parent_id":85676611,
     "wof:placetype":"county",

--- a/data/110/874/795/5/1108747955.geojson
+++ b/data/110/874/795/5/1108747955.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747955,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886761,
     "wof:name":"Rakwon",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/795/7/1108747957.geojson
+++ b/data/110/874/795/7/1108747957.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747957,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886761,
     "wof:name":"Rangrim",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/796/5/1108747965.geojson
+++ b/data/110/874/796/5/1108747965.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747965,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886762,
     "wof:name":"Ryongchon",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/796/7/1108747967.geojson
+++ b/data/110/874/796/7/1108747967.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747967,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886762,
     "wof:name":"Ryongchon",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/796/9/1108747969.geojson
+++ b/data/110/874/796/9/1108747969.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108747969,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886762,
     "wof:name":"Ryonggang",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/874/799/9/1108747999.geojson
+++ b/data/110/874/799/9/1108747999.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108747999,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886762,
     "wof:name":"Sinkye",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/800/1/1108748001.geojson
+++ b/data/110/874/800/1/1108748001.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748001,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886763,
     "wof:name":"Sinphyong",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/800/3/1108748003.geojson
+++ b/data/110/874/800/3/1108748003.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748003,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886763,
     "wof:name":"Sinpo City",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/800/5/1108748005.geojson
+++ b/data/110/874/800/5/1108748005.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748005,
-    "wof:lastmodified":1694498057,
+    "wof:lastmodified":1695886763,
     "wof:name":"Sinuiju City",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/800/9/1108748009.geojson
+++ b/data/110/874/800/9/1108748009.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748009,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886763,
     "wof:name":"Sinwon",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/801/9/1108748019.geojson
+++ b/data/110/874/801/9/1108748019.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748019,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886763,
     "wof:name":"Songgan",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/802/1/1108748021.geojson
+++ b/data/110/874/802/1/1108748021.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748021,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886763,
     "wof:name":"Songhwa",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/802/3/1108748023.geojson
+++ b/data/110/874/802/3/1108748023.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748023,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886763,
     "wof:name":"Songrim City",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/802/7/1108748027.geojson
+++ b/data/110/874/802/7/1108748027.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748027,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886763,
     "wof:name":"Songwon",
     "wof:parent_id":85676623,
     "wof:placetype":"county",

--- a/data/110/874/802/9/1108748029.geojson
+++ b/data/110/874/802/9/1108748029.geojson
@@ -77,7 +77,7 @@
         }
     ],
     "wof:id":1108748029,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886763,
     "wof:name":"Suan",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/803/1/1108748031.geojson
+++ b/data/110/874/803/1/1108748031.geojson
@@ -89,7 +89,7 @@
         }
     ],
     "wof:id":1108748031,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886763,
     "wof:name":"Sudong",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/803/3/1108748033.geojson
+++ b/data/110/874/803/3/1108748033.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748033,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886763,
     "wof:name":"Sukchon",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/803/5/1108748035.geojson
+++ b/data/110/874/803/5/1108748035.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748035,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886763,
     "wof:name":"Sunchon City",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/803/7/1108748037.geojson
+++ b/data/110/874/803/7/1108748037.geojson
@@ -69,7 +69,7 @@
         }
     ],
     "wof:id":1108748037,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886763,
     "wof:name":"Taean",
     "wof:parent_id":-1,
     "wof:placetype":"county",

--- a/data/110/874/803/9/1108748039.geojson
+++ b/data/110/874/803/9/1108748039.geojson
@@ -134,7 +134,7 @@
         }
     ],
     "wof:id":1108748039,
-    "wof:lastmodified":1694498096,
+    "wof:lastmodified":1695886623,
     "wof:name":"Taedong",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/804/1/1108748041.geojson
+++ b/data/110/874/804/1/1108748041.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748041,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886763,
     "wof:name":"Taegwan",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/804/5/1108748045.geojson
+++ b/data/110/874/804/5/1108748045.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748045,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886764,
     "wof:name":"Taehongdan",
     "wof:parent_id":85676641,
     "wof:placetype":"county",

--- a/data/110/874/804/7/1108748047.geojson
+++ b/data/110/874/804/7/1108748047.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748047,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886764,
     "wof:name":"Taehung",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/804/9/1108748049.geojson
+++ b/data/110/874/804/9/1108748049.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748049,
-    "wof:lastmodified":1694498058,
+    "wof:lastmodified":1695886764,
     "wof:name":"Tanchon City",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/808/9/1108748089.geojson
+++ b/data/110/874/808/9/1108748089.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748089,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886766,
     "wof:name":"Unsan",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/809/1/1108748091.geojson
+++ b/data/110/874/809/1/1108748091.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748091,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886766,
     "wof:name":"Unsan",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/810/1/1108748101.geojson
+++ b/data/110/874/810/1/1108748101.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748101,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886766,
     "wof:name":"Yangdok",
     "wof:parent_id":85676637,
     "wof:placetype":"county",

--- a/data/110/874/810/3/1108748103.geojson
+++ b/data/110/874/810/3/1108748103.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748103,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886766,
     "wof:name":"Yodok",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/810/5/1108748105.geojson
+++ b/data/110/874/810/5/1108748105.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748105,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886766,
     "wof:name":"Yomju",
     "wof:parent_id":85676633,
     "wof:placetype":"county",

--- a/data/110/874/810/7/1108748107.geojson
+++ b/data/110/874/810/7/1108748107.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748107,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886766,
     "wof:name":"Yonan",
     "wof:parent_id":85676605,
     "wof:placetype":"county",

--- a/data/110/874/810/9/1108748109.geojson
+++ b/data/110/874/810/9/1108748109.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748109,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886767,
     "wof:name":"Yonggwan",
     "wof:parent_id":85676629,
     "wof:placetype":"county",

--- a/data/110/874/811/1/1108748111.geojson
+++ b/data/110/874/811/1/1108748111.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748111,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886767,
     "wof:name":"Yonsan",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/110/874/811/3/1108748113.geojson
+++ b/data/110/874/811/3/1108748113.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748113,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886767,
     "wof:name":"Yonsa",
     "wof:parent_id":85676615,
     "wof:placetype":"county",

--- a/data/110/874/811/7/1108748117.geojson
+++ b/data/110/874/811/7/1108748117.geojson
@@ -62,7 +62,7 @@
         }
     ],
     "wof:id":1108748117,
-    "wof:lastmodified":1694498059,
+    "wof:lastmodified":1695886767,
     "wof:name":"Yonthan",
     "wof:parent_id":85676603,
     "wof:placetype":"county",

--- a/data/421/199/693/421199693.geojson
+++ b/data/421/199/693/421199693.geojson
@@ -69,8 +69,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":20070114,
+        "iso:code":"KP-14",
         "qs_pg:id":484686
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KP",
     "wof:created":1459009998,
     "wof:geom_alt":[
@@ -91,7 +93,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1694493254,
+    "wof:lastmodified":1695884754,
     "wof:name":"Namp\u00b4o-si",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/326/39/85632639.geojson
+++ b/data/856/326/39/85632639.geojson
@@ -1369,6 +1369,7 @@
         "hasc:id":"KP",
         "icao:code":"P",
         "ioc:id":"PRK",
+        "iso:code":"KP",
         "itu:id":"KRE",
         "loc:id":"n81074720",
         "m49:code":"408",
@@ -1382,6 +1383,7 @@
         "wk:page":"North Korea",
         "wmo:id":"KR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KP",
     "wof:country_alpha3":"PRK",
     "wof:geom_alt":[
@@ -1404,7 +1406,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1694639586,
+    "wof:lastmodified":1695881246,
     "wof:name":"North Korea",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/766/03/85676603.geojson
+++ b/data/856/766/03/85676603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.0678,
-    "geom:area_square_m":10326761336.801994,
+    "geom:area_square_m":10326760590.200655,
     "geom:bbox":"125.520837,37.771137,127.019449,39.172322",
     "geom:latitude":38.543889,
     "geom:longitude":126.328421,
@@ -302,16 +302,18 @@
         "gn:id":1876888,
         "gp:id":2345953,
         "hasc:id":"KP.WK",
+        "iso:code":"KP-06",
         "iso:id":"KP-06",
         "qs_pg:id":890081,
         "wd:id":"Q109342",
         "wk:page":"North Hwanghae Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KP",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b4a583b0986319013c4753b0711b9bdc",
+    "wof:geomhash":"95934d1822172ac69dfeff3845fec3f0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938204,
+    "wof:lastmodified":1695884784,
     "wof:name":"Hwanghae-bukto",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/05/85676605.geojson
+++ b/data/856/766/05/85676605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.848372,
-    "geom:area_square_m":8245066288.925491,
+    "geom:area_square_m":8245065376.803502,
     "geom:bbox":"124.652031,37.677082,126.441955,38.717056",
     "geom:latitude":38.188801,
     "geom:longitude":125.539535,
@@ -302,16 +302,18 @@
         "gn:id":1876884,
         "gp:id":2345952,
         "hasc:id":"KP.WN",
+        "iso:code":"KP-05",
         "iso:id":"KP-05",
         "qs_pg:id":894910,
         "wd:id":"Q626052",
         "wk:page":"South Hwanghae Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KP",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7131d246ed076a7377c54475d3a1fb82",
+    "wof:geomhash":"1a6060b089bab7e8f4f006451f7d0671",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938205,
+    "wof:lastmodified":1695884784,
     "wof:name":"Hwanghae-namdo",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/11/85676611.geojson
+++ b/data/856/766/11/85676611.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.183271,
-    "geom:area_square_m":1759227940.09467,
+    "geom:area_square_m":1759227969.655266,
     "geom:bbox":"125.575918,38.894989,126.389143,39.283522",
     "geom:latitude":39.077338,
     "geom:longitude":125.921317,
@@ -695,15 +695,17 @@
         "gn:id":1871856,
         "gp:id":20070115,
         "hasc:id":"KP.PY",
+        "iso:code":"KP-01",
         "iso:id":"KP-01",
         "qs_pg:id":425214,
         "wd:id":"Q18808"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KP",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"50369a0a3039664e9cc3e2f2f26d5e4c",
+    "wof:geomhash":"f95105b0408ef70693ab200b52657888",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -718,7 +720,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938206,
+    "wof:lastmodified":1695884518,
     "wof:name":"P'y\u014fngyang",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/15/85676615.geojson
+++ b/data/856/766/15/85676615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.720685,
-    "geom:area_square_m":15858219289.043646,
+    "geom:area_square_m":15858219694.433329,
     "geom:bbox":"128.806263,40.569365,130.437109,43.01159",
     "geom:latitude":41.808573,
     "geom:longitude":129.543079,
@@ -220,16 +220,18 @@
         "gn:id":2044245,
         "gp:id":2345958,
         "hasc:id":"KP.HG",
+        "iso:code":"KP-09",
         "iso:id":"KP-09",
         "qs_pg:id":894912,
         "wd:id":"Q109361",
         "wk:page":"North Hamgyong Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KP",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a9b8d7fb79ec754f42564a932d26a2f2",
+    "wof:geomhash":"3e66f64958e1d7bc1e5daf17a760d11c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -244,7 +246,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938208,
+    "wof:lastmodified":1695884332,
     "wof:name":"Hamgy\u014fng-bukto",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/19/85676619.geojson
+++ b/data/856/766/19/85676619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.159659,
-    "geom:area_square_m":11187572518.107368,
+    "geom:area_square_m":11187571858.055832,
     "geom:bbox":"126.677497,38.162552,128.365494,39.41888",
     "geom:latitude":38.72053,
     "geom:longitude":127.462067,
@@ -324,16 +324,18 @@
         "gn:id":1876101,
         "gp:id":2345954,
         "hasc:id":"KP.KW",
+        "iso:code":"KP-07",
         "iso:id":"KP-07",
         "qs_pg:id":890082,
         "wd:id":"Q41416",
         "wk:page":"Kangwon Province (North Korea)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KP",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1bce538a1dc625744a600a740f796359",
+    "wof:geomhash":"2c5b0f9889ec937ec48f17cf95fc16c4",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -348,7 +350,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938206,
+    "wof:lastmodified":1695884332,
     "wof:name":"Kangw\u014fn-do",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/23/85676623.geojson
+++ b/data/856/766/23/85676623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.785066,
-    "geom:area_square_m":16711114964.527027,
+    "geom:area_square_m":16711114827.199291,
     "geom:bbox":"125.407656,39.991331,127.507275,41.808651",
     "geom:latitude":40.789689,
     "geom:longitude":126.515853,
@@ -326,16 +326,18 @@
         "gn:id":2045265,
         "gp:id":2345950,
         "hasc:id":"KP.CH",
+        "iso:code":"KP-04",
         "iso:id":"KP-04",
         "qs_pg:id":1311260,
         "wd:id":"Q272406",
         "wk:page":"Chagang Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KP",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0627a64d55348b0d14e96a3461dd0ca1",
+    "wof:geomhash":"413bda1443c2af3faaf30fb69f04d75d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -350,7 +352,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938208,
+    "wof:lastmodified":1695884785,
     "wof:name":"Chagang-do",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/29/85676629.geojson
+++ b/data/856/766/29/85676629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.962309,
-    "geom:area_square_m":18514179242.411831,
+    "geom:area_square_m":18514178872.714268,
     "geom:bbox":"126.669766,39.203505,129.15762,41.1782",
     "geom:latitude":40.266694,
     "geom:longitude":127.801295,
@@ -318,16 +318,18 @@
         "gn:id":1877450,
         "gp:id":2345951,
         "hasc:id":"KP.HN",
+        "iso:code":"KP-08",
         "iso:id":"KP-08",
         "qs_pg:id":235601,
         "wd:id":"Q109368",
         "wk:page":"South Hamgyong Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KP",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0adf84b4c13363005f4b65419dac8fcf",
+    "wof:geomhash":"7282cc65906c0b1650afbcf96ff4b416",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -342,7 +344,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938206,
+    "wof:lastmodified":1695884518,
     "wof:name":"Hamgy\u014fng-namdo",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/33/85676633.geojson
+++ b/data/856/766/33/85676633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.301738,
-    "geom:area_square_m":12322958484.419006,
+    "geom:area_square_m":12322959213.861059,
     "geom:bbox":"124.204582,39.427082,126.370706,40.656533",
     "geom:latitude":40.040756,
     "geom:longitude":125.265142,
@@ -321,16 +321,18 @@
         "gn:id":1871954,
         "gp:id":2345955,
         "hasc:id":"KP.PB",
+        "iso:code":"KP-03",
         "iso:id":"KP-03",
         "qs_pg:id":1222519,
         "wd:id":"Q109348",
         "wk:page":"North Pyongan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KP",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3a55b0a67dd0abc0615f560dad500ed4",
+    "wof:geomhash":"1950f9616245a7772d3e12abb4f993e9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -345,7 +347,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938205,
+    "wof:lastmodified":1695884518,
     "wof:name":"P'y\u014fngan-bukto",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/37/85676637.geojson
+++ b/data/856/766/37/85676637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.183479,
-    "geom:area_square_m":11284592881.681959,
+    "geom:area_square_m":11284592290.737738,
     "geom:bbox":"125.209752,38.905362,127.178171,40.337877",
     "geom:latitude":39.543895,
     "geom:longitude":126.286566,
@@ -315,16 +315,18 @@
         "gn:id":1871952,
         "gp:id":2345957,
         "hasc:id":"KP.PM",
+        "iso:code":"KP-02",
         "iso:id":"KP-02",
         "qs_pg:id":1222521,
         "wd:id":"Q109380",
         "wk:page":"South Pyongan Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KP",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6bc0b090e862064b375d4385d6ff7712",
+    "wof:geomhash":"f3d8d56d151044f3be9b96e8337ea069",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -339,7 +341,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938207,
+    "wof:lastmodified":1695884332,
     "wof:name":"P'y\u014fngan-namdo",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/41/85676641.geojson
+++ b/data/856/766/41/85676641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.494319,
-    "geom:area_square_m":13879688560.820448,
+    "geom:area_square_m":13879688416.873253,
     "geom:bbox":"126.911261,40.413809,129.057812,42.099521",
     "geom:latitude":41.307239,
     "geom:longitude":128.169919,
@@ -318,17 +318,19 @@
         "gn:id":2039332,
         "gp:id":2345956,
         "hasc:id":"KP.YG",
+        "iso:code":"KP-10",
         "iso:id":"KP-10",
         "qs_pg:id":1222520,
         "unlc:id":"KP-10",
         "wd:id":"Q110171",
         "wk:page":"Ryanggang Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KP",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"29f8f6e5e9d965f9060726cd2839fc40",
+    "wof:geomhash":"a8fa6c594ae864ddc3da6d85191d1276",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -343,7 +345,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1690938207,
+    "wof:lastmodified":1695884785,
     "wof:name":"Ryanggang",
     "wof:parent_id":85632639,
     "wof:placetype":"region",

--- a/data/856/766/47/85676647.geojson
+++ b/data/856/766/47/85676647.geojson
@@ -207,10 +207,12 @@
     "wof:concordances":{
         "gn:id":2044245,
         "gp:id":2345958,
+        "iso:code":"KP-13",
         "qs_pg:id":894912,
         "wd:id":"Q109361",
         "wk:page":"North Hamgyong Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"KP",
     "wof:geom_alt":[
         "quattroshapes"
@@ -230,7 +232,7 @@
     "wof:lang_x_spoken":[
         "kor"
     ],
-    "wof:lastmodified":1694493174,
+    "wof:lastmodified":1695884519,
     "wof:name":"Ras\u014fn",
     "wof:parent_id":85632639,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.